### PR TITLE
Fix #2: support pruning and forget via snapshot policies

### DIFF
--- a/src/autorestic.ts
+++ b/src/autorestic.ts
@@ -18,8 +18,9 @@ export const { _: commands, ...flags } = minimist(process.argv.slice(2), {
     a: 'all',
     l: 'location',
     b: 'backend',
+    d: 'dry-run',
   },
-  boolean: ['a'],
+  boolean: ['a', 'd'],
   string: ['l', 'b'],
 })
 

--- a/src/forget.ts
+++ b/src/forget.ts
@@ -1,0 +1,60 @@
+import { Writer } from 'clitastic'
+
+import { config, VERBOSE } from './autorestic'
+import { getEnvFromBackend } from './backend'
+import { Locations, Location, ForgetPolicy, Flags } from './types'
+import { exec, ConfigError } from './utils'
+
+export const forgetSingle = (dryRun: boolean, name: string, from: string, to: string, policy: ForgetPolicy) => {
+  if (!config) throw ConfigError
+  const writer = new Writer(name + to.blue + ' : ' + 'Removing old spnapshots… ⏳')
+  const backend = config.backends[to]
+  const flags = [] as any[]
+  for (const [name, value] of Object.entries(policy)) {
+    flags.push(`--keep-${name}`)
+    flags.push(value)
+  }
+  if (dryRun) {
+    flags.push('--dry-run')
+  }
+  const env = getEnvFromBackend(backend)
+  writer.appendLn(name + to.blue + ' : ' + 'Forgeting old snapshots… ⏳')
+  const cmd = exec('restic', ['forget', '--path', from, '--prune', ...flags], {env})
+
+  if (VERBOSE) console.log(cmd.out, cmd.err)
+  writer.done(name + to.blue + ' : ' + 'Done ✓'.green)
+}
+
+export const forgetLocation = (dryRun: boolean, name: string, backup: Location, policy?: ForgetPolicy) => {
+  const display = name.yellow + ' ▶ '
+  if (!policy) {
+    console.log(display + 'skipping, no policy declared')
+  }
+  else {
+    if (Array.isArray(backup.to)) {
+      let first = true
+      for (const t of backup.to) {
+        const nameOrBlankSpaces: string = first
+          ? display
+          : new Array(name.length + 3).fill(' ').join('')
+        forgetSingle(dryRun, nameOrBlankSpaces, backup.from, t, policy)
+        if (first) first = false
+      }
+    } else forgetSingle(dryRun, display, backup.from, backup.to, policy)
+  }
+  }
+
+export const forgetAll = (dryRun: boolean, backups?: Locations) => {
+  if (!config) throw ConfigError
+  if (!backups) {
+    backups = config.locations
+  }
+
+  console.log('\nRemoving old shapshots according to policy'.underline.grey)
+  if (dryRun) console.log('Running in dry-run mode, not touching data\n'.yellow)
+
+  for (const [name, backup] of Object.entries(backups)) {
+    var policy = config.locations[name].keep
+    forgetLocation(dryRun, name, backup, policy)
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,9 +62,21 @@ export type Backend =
 
 export type Backends = { [name: string]: Backend }
 
+export type ForgetPolicy = {
+  last?: number,
+  hourly?: number,
+  daily?: number,
+  weekly?: number,
+  monthly?: number,
+  yearly?: number,
+  within?: string,
+  tags?: string[],
+}
+
 export type Location = {
   from: string
   to: string | string[]
+  keep?: ForgetPolicy
 }
 
 export type Locations = { [name: string]: Location }


### PR DESCRIPTION
Implements #2, and include documentation about the feature (included below for easier understanding):

This includes support for runing with dry-run. Let me know what you think about the API / feature.

## Pruning and snapshot policies

Autorestic supports declaring snapshot policies for location to avoid keeping old snapshot around if you don't need them.

This is based on [Restic's snapshots policies](https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy), and can be enabled for each location as shown below:

```yaml
locations:
  etc:
    from: /etc
    to: local
    keep:
      # options matches the --keep-* options used in the restic forget CLI
      # cf https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
      last: 5             # always keep at least 5 snapshots
      hourly: 3           # keep 3 last hourly shapshots
      daily: 4            # keep 4 last daily shapshots
      weekly: 1           # keep 1 last weekly shapshots
      monthly: 12         # keep 12 last monthly shapshots
      yearly: 7           # keep 7 last yearly shapshots
      within: "2w"        # keep snapshots from the last 2 weeks
```

Pruning can be triggered using `autorestic forget -a`, for all locations, or selectively with `autorestic forget -l <location>`. **please note that contrary to the restic CLI, `restic forget` will call `restic prune` internally.**



Run with the `--dry-run` flag to only print information about the process without actually pruning the snapshots. This is especially useful for debugging or testing policies:

```
$ autorestic forget -a --dry-run --verbose

Configuring Backends
local : Done ✓

Removing old shapshots according to policy
etc ▶ local : Removing old spnapshots… ⏳
etc ▶ local : Running in dry-run mode, not touching data
etc ▶ local : Forgeting old snapshots… ⏳Applying Policy: all snapshots within 2d of the newest
keep 3 snapshots:
ID        Time                 Host        Tags        Reasons    Paths
-----------------------------------------------------------------------------
531b692a  2019-12-02 12:07:28  computer                within 2w  /etc
51659674  2019-12-02 12:08:46  computer                within 2w  /etc
f8f8f976  2019-12-02 12:11:08  computer                within 2w  /etc
-----------------------------------------------------------------------------
3 snapshots
```