### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/markdown/cli/cron.md
+++ b/docs/markdown/cli/cron.md
@@ -6,6 +6,6 @@ autorestic cron
 
 This command is mostly intended to be triggered by an automated system like systemd or crontab.
 
-It will run cron jobs es [specified in the cron section](/locations/cron) of a specific location.
+It will run cron jobs as [specified in the cron section](/location/cron) of a specific location.
 
 > :ToCPrevNext


### PR DESCRIPTION
Came across this invalid link while reading the docs (https://autorestic.vercel.app/cli/cron)