### PR TITLE
Recommend a consistent config location

### DIFF
--- a/docs/markdown/location/cron.md
+++ b/docs/markdown/location/cron.md
@@ -30,14 +30,14 @@ First, open your crontab in edit mode
 crontab -e
 ```
 
-Then paste this at the bottom of the file and save it. Note that in this specific example the `.autorestic.yml` is located in `/srv/`. You need to modify that part of course to fit your config file.
+Then paste this at the bottom of the file and save it. Note that in this specific example the config file is located at one of the default locations (e.g. `~/.autorestic.yml`). If your config is somewhere else you'll need to specify it using the `-c` option.
 
 ```bash
 # This is required, as it otherwise cannot find restic as a command.
 PATH="/usr/local/bin:/usr/bin:/bin"
 
 # Example running every 5 minutes
-*/5 * * * * autorestic -c /srv/.autorestic.yml --ci cron
+*/5 * * * * autorestic --ci cron
 ```
 
 > The `--ci` option is not required, but recommended

--- a/docs/markdown/quick.md
+++ b/docs/markdown/quick.md
@@ -9,7 +9,7 @@ curl -s https://raw.githubusercontent.com/CupCakeArmy/autorestic/master/install.
 ## Write a simple config file
 
 ```bash
-vim .autorestic.yml
+vim ~/.autorestic.yml
 ```
 
 For a quick overview:


### PR DESCRIPTION
Hello! I ran into a couple minor snags setting up autorestic so I thought I'd try to improve them.

It seems like the default place to put your config file is the home directory so I made that consistent throughout the docs. In particular I didn't read carefully when setting up my cron job initially and left it pointing to `/srv/.autorestic.yml`. For me at least cron ran it as the correct user so I was able to omit the `-c` option entirely.