### PR TITLE
Update Backblaze docs

### DIFF
--- a/docs/markdown/backend/available.md
+++ b/docs/markdown/backend/available.md
@@ -19,16 +19,15 @@ backends:
 backends:
   name-of-backend:
     type: b2
-    path: 'myAccount:myBucket/my/path'
+    path: 'backblaze_bucketID'
     env:
-      B2_ACCOUNT_ID: backblaze_account_id
-      B2_ACCOUNT_KEY: backblaze_account_key
+      B2_ACCOUNT_ID: 'backblaze_keyID'
+      B2_ACCOUNT_KEY: 'backblaze_applicationKey'
 ```
 
 #### API Keys gotcha
 
-When creating API make sure you check _Allow List All Bucket Names_ if you allow access to a single bucket only.
-Also make sure that the _File name prefix_ (if used) does not includes a leading slash.
+If you use a _File name prefix_ when making the application key, do not include a leading slash. Make sure to include this prefix in the path (e.g. `path: 'backblaze_bucketID:my/path'`).
 
 ## S3 / Minio
 


### PR DESCRIPTION
Hello! I ran into a couple minor snags setting up autorestic so I thought I'd try to improve them.

- The restic docs don't seem to mention any sort of account ID being necessary for Backblaze backend paths and looking at my Backblaze dashboard I'm not even sure what it would be. I removed it without issue in my config and so removed it from the docs.
- I'm guessing the default use case is to set up a dedicated bucket so I removed the prefix from the example config.
- Based on restic docs and looking through autorestic's code it looks like a prefix should be `:` delimited from the bucket ID. **I didn't test this and I'm not sure if the note about leading slashes still applies.**
- The restic docs also don't mention anything about the _Allow List All Bucket Names_ option and it didn't seem to be necessary for me so I removed that note.
- I updated the names of values in the docs to better reflect Backblaze's terminology.