### PR TITLE
correction to B2 config in the example

### DIFF
--- a/docs/markdown/config.md
+++ b/docs/markdown/config.md
@@ -31,8 +31,9 @@ backends:
   remote:
     type: b2
     path: 'myBucket:backup/home'
-    B2_ACCOUNT_ID: account_id
-    B2_ACCOUNT_KEY: account_key
+    env:
+      B2_ACCOUNT_ID: account_id
+      B2_ACCOUNT_KEY: account_key
 
   hdd:
     type: local


### PR DESCRIPTION
This example was missing the `env:` block in YAML, which if missing, caused `autorestic check` to compain:

``` * 'Backends[remote]' has invalid keys: b2_account_id, b2_account_key```