### PR TITLE
Add third ansible role to community docs

### DIFF
--- a/docs/markdown/community.md
+++ b/docs/markdown/community.md
@@ -6,5 +6,6 @@ A list of community driven projects. (No official affiliation)
 - Docker image: https://github.com/pascaliske/docker-autorestic
 - Ansible Role: https://github.com/adsanz/ansible-restic-role
 - Ansible Role: https://github.com/ItsNotGoodName/ansible-role-autorestic
+- Ansible Role: https://github.com/FuzzyMistborn/ansible-role-autorestic
 
 > :ToCPrevNext


### PR DESCRIPTION
I hadn't found those other roles so I made my own.