### PR TITLE
Add error handling to reading of config file.

### DIFF
--- a/docs/markdown/docker.md
+++ b/docs/markdown/docker.md
@@ -10,7 +10,7 @@ For remote backups (S3, B2, GCS, etc.) it's quite easy, as you only need to moun
 docker run --rm \\
   -v $(pwd):/data \\
   cupcakearmy/autorestic \\
-  autorestic backup -va
+  autorestic backup -va -c /data/.autorestic.yaml
 ```
 
 ## Rclone


### PR DESCRIPTION
To test:
```
docker build -t local-autorestic .
docker run --rm local-autorestic autorestic check -v
```

expected results:
```
> Adding config path: '.'
> Adding config path: 'autorestic'
cannot find configuration file '.autorestic.yml' or '.autorestic.yaml' in config paths: ['.', 'autorestic']
```