### PR TITLE
Make a copy of config before overriding it

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -259,7 +259,7 @@ func (c *Config) SaveConfig() error {
 	if err := CopyFile(file, file+".old"); err != nil {
 		return err
 	}
-	colors.Secondary.Println("Saved a backup copy of your file next the the original.")
+	colors.Secondary.Println("Saved a backup copy of your file next to the original.")
 
 	viper.Set("backends", c.Backends)
 	viper.Set("locations", c.Locations)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -60,13 +60,13 @@ func ExecuteResticCommand(options ExecuteOptions, args ...string) (string, error
 }
 
 func CopyFile(from, to string) error {
-	original, err := os.Open("original.txt")
+	original, err := os.Open(from)
 	if err != nil {
 		return nil
 	}
 	defer original.Close()
 
-	new, err := os.Create("new.txt")
+	new, err := os.Create(to)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
## Does not work (current latest image)
```
# create test config
print "version: 2\nbackends:\n  localtmp:\n    type: local\n    path: /tmp/backup-backend\nlocations:\n  data:\n    from:\n    - /data/\n    to:\n    - localtmp" | tee test-config.yaml

# autorestic check 
docker run --rm -v $(pwd):/data cupcakearmy/autorestic autorestic -c /data/test-config.yaml check -v

# list all files matching pattern
ls -l test-config.*
```
output (no file with `.old` extension) :
```
janr@Jans-MacBook-Pro autorestic % ls -l test-config.*
-rw-r--r--  1 janr  staff  232 Feb  9 20:47 test-config.yaml
```


## Working:
```
# build from branch sources
docker build -t local-autorestic .

# create test config
print "version: 2\nbackends:\n  localtmp:\n    type: local\n    path: /tmp/backup-backend\nlocations:\n  data:\n    from:\n    - /data/\n    to:\n    - localtmp" | tee test-config.yaml

# autorestic check 
docker run --rm -v $(pwd):/data local-autorestic autorestic -c /data/test-config.yaml check -v

# list all files matching pattern
ls -l test-config.*
```

output:
```
Everything is fine.
janr@Jans-MacBook-Pro autorestic % ls -l test-config.*
-rw-r--r--  1 janr  staff  239 Feb  9 20:52 test-config.yaml
-rw-r--r--  1 janr  staff  144 Feb  9 20:52 test-config.yaml.old
janr@Jans-MacBook-Pro autorestic % 
```
