### PR TITLE
Add lower case warning for backend name

### DIFF
--- a/docs/markdown/backend/overview.md
+++ b/docs/markdown/backend/overview.md
@@ -1,6 +1,7 @@
 # 💽 Backends
 
 Backends are the outputs of the backup process. Each location needs at least one.
+Note: names of backends MUST be lower case!
 
 ```yaml | .autorestic.yml
 version: 2

--- a/docs/markdown/backend/overview.md
+++ b/docs/markdown/backend/overview.md
@@ -1,6 +1,7 @@
 # 💽 Backends
 
 Backends are the outputs of the backup process. Each location needs at least one.
+
 Note: names of backends MUST be lower case!
 
 ```yaml | .autorestic.yml

--- a/docs/markdown/location/overview.md
+++ b/docs/markdown/location/overview.md
@@ -3,6 +3,7 @@
 Locations can be seen as the input to the backup process. Generally this is simply a folder.
 The paths can be relative from the config file. A location can have multiple backends, so that the data is secured across multiple servers.
 
+Note: names of locations MUST be lower case!
 ```yaml | .autorestic.yml
 version: 2
 


### PR DESCRIPTION
If uppercase characters are used in a backend name a check (and I assume other actions) will fail.