### PR TITLE
DOC - Note on config filename extension

### DIFF
--- a/docs/markdown/cli/general.md
+++ b/docs/markdown/cli/general.md
@@ -2,7 +2,7 @@
 
 ## `-c, --config`
 
-Specify the config file to be used.
+Specify the config file to be used (must use .yml as an extension).
 If omitted `autorestic` will search for for a `.autorestic.yml` in the current directory and your home directory.
 
 ```bash


### PR DESCRIPTION
Seems the config file can be located wherever needed but not using an extension or using an extension other than .yml causes the following error
could not load config file
Unsupported Config Type ""