### PR TITLE
Write forget and copy options with correct name

### DIFF
--- a/cmd/forget.go
+++ b/cmd/forget.go
@@ -21,7 +21,7 @@ var forgetCmd = &cobra.Command{
 		dry, _ := cmd.Flags().GetBool("dry-run")
 		for _, name := range selected {
 			location, _ := internal.GetLocation(name)
-			err := location.Forget(prune, dry)
+			err := location.DoForget(prune, dry)
 			CheckErr(err)
 		}
 	},


### PR DESCRIPTION
This PR attempts to fix #194 : when config is written back (for now, only when generating a secret key for a new repository), `forget` and `copy` field of locations are written with an invalid name.

This PR only does renaming in the code so that current configs still work while writing the correct field names.