### PR TITLE
Use YAML options when calling check or init

### DIFF
--- a/internal/backend.go
+++ b/internal/backend.go
@@ -121,13 +121,17 @@ func (b Backend) validate() error {
 	}
 	options := ExecuteOptions{Envs: env, Silent: true}
 	// Check if already initialized
-	_, _, err = ExecuteResticCommand(options, "check")
+	cmd := []string{"check"}
+	cmd = append(cmd, combineBackendOptions("check", b)...)
+	_, _, err = ExecuteResticCommand(options, cmd...)
 	if err == nil {
 		return nil
 	} else {
 		// If not initialize
 		colors.Body.Printf("Initializing backend \"%s\"...\n", b.name)
-		_, _, err := ExecuteResticCommand(options, "init")
+		cmd := []string{"init"}
+		cmd = append(cmd, combineBackendOptions("init", b)...)
+		_, _, err := ExecuteResticCommand(options, cmd...)
 		return err
 	}
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -303,7 +303,17 @@ func getOptions(options Options, keys []string) []string {
 	return selected
 }
 
-func combineOptions(key string, l Location, b Backend) []string {
+func combineBackendOptions(key string, b Backend) []string {
+	// Priority: backend > global
+	var options []string
+	gFlags := getOptions(GetConfig().Global, []string{key})
+	bFlags := getOptions(b.Options, []string{"all", key})
+	options = append(options, gFlags...)
+	options = append(options, bFlags...)
+	return options
+}
+
+func combineAllOptions(key string, l Location, b Backend) []string {
 	// Priority: location > backend > global
 	var options []string
 	gFlags := getOptions(GetConfig().Global, []string{key})

--- a/internal/location.go
+++ b/internal/location.go
@@ -220,7 +220,7 @@ func (l Location) Backup(cron bool, specificBackend string) []error {
 		}
 
 		cmd := []string{"backup"}
-		cmd = append(cmd, combineOptions("backup", l, backend)...)
+		cmd = append(cmd, combineAllOptions("backup", l, backend)...)
 		if cron {
 			cmd = append(cmd, "--tag", buildTag("cron"))
 		}
@@ -341,7 +341,7 @@ func (l Location) Forget(prune bool, dry bool) error {
 		if dry {
 			cmd = append(cmd, "--dry-run")
 		}
-		cmd = append(cmd, combineOptions("forget", l, backend)...)
+		cmd = append(cmd, combineAllOptions("forget", l, backend)...)
 		_, _, err = ExecuteResticCommand(options, cmd...)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR attempts to fix #198. 

It mimics the utility function that merges all `options` for a given command, but as `check` or `init` are backend-related, we don't have a `Location` object to call the existing function.
 
It works, however I am not familiar with Go and I find my code little elegant. Feel free to improve it ! :)
