### PR TITLE
Add lock tests

### DIFF
--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -31,7 +31,7 @@ func TestLock(t *testing.T) {
 	setup(t)
 
 	t.Run("getLock", func(t *testing.T) {
-		result := getLock().GetBool("running")
+		result := getLock().GetBool(RUNNING)
 
 		if result {
 			t.Errorf("got %v, want %v", result, false)
@@ -39,24 +39,24 @@ func TestLock(t *testing.T) {
 	})
 
 	t.Run("lock", func(t *testing.T) {
-		err := Lock()
+		lock, err := setLockValue(RUNNING, true)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 
-		result := getLock().GetBool("running")
+		result := lock.GetBool(RUNNING)
 		if !result {
 			t.Errorf("got %v, want %v", result, true)
 		}
 	})
 
 	t.Run("unlock", func(t *testing.T) {
-		err := Unlock()
+		lock, err := setLockValue(RUNNING, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 
-		result := getLock().GetBool("running")
+		result := lock.GetBool(RUNNING)
 		if result {
 			t.Errorf("got %v, want %v", result, false)
 		}

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,0 +1,86 @@
+package lock
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+var testDirectory = "autorestic_test_tmp"
+
+// All tests must share the same lock file as it is only initialized once
+func setup(t *testing.T) {
+	d, err := os.MkdirTemp("", testDirectory)
+	if err != nil {
+		log.Fatalf("error creating temp dir: %v", err)
+		return
+	}
+	// set config file location
+	viper.SetConfigFile(d + "/.autorestic.yml")
+
+	t.Cleanup(func() {
+		os.RemoveAll(d)
+		viper.Reset()
+	})
+}
+
+func TestLock(t *testing.T) {
+	setup(t)
+
+	t.Run("getLock", func(t *testing.T) {
+		result := getLock().GetBool("running")
+
+		if result {
+			t.Errorf("got %v, want %v", result, false)
+		}
+	})
+
+	t.Run("lock", func(t *testing.T) {
+		err := Lock()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		result := getLock().GetBool("running")
+		if !result {
+			t.Errorf("got %v, want %v", result, true)
+		}
+	})
+
+	t.Run("unlock", func(t *testing.T) {
+		err := Unlock()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		result := getLock().GetBool("running")
+		if result {
+			t.Errorf("got %v, want %v", result, false)
+		}
+	})
+
+	t.Run("set cron", func(t *testing.T) {
+		expected := int64(5)
+		SetCron("foo", expected)
+
+		result, err := strconv.ParseInt(getLock().GetString("cron.foo"), 10, 64)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result != expected {
+			t.Errorf("got %d, want %d", result, expected)
+		}
+	})
+
+	t.Run("get cron", func(t *testing.T) {
+		expected := int64(5)
+		result := GetCron("foo")
+
+		if result != expected {
+			t.Errorf("got %d, want %d", result, expected)
+		}
+	})
+}


### PR DESCRIPTION
Related to #204. This PR adds tests for `lock.go`.

I refactored `setLock` to `setLockValue` for setting key, value pairs in the lock config file. This lets `SetCron` and `Lock` use the same standardized function. 

Also, I didn't like that I was calling `getLock` in the tests to check a specific config value every time. So, `setLockValue` returns the lock object for better testing. Since its not exported, it shouldn't affect the other files.

I would also like to test the behaviour of `Lock` when its called twice in a row. Since that results in an `os.Exit` call, I'm still thinking about how to ensure it does not affect the other tests.