### PR TITLE
Don't check if path is a directory

### DIFF
--- a/internal/location.go
+++ b/internal/location.go
@@ -74,12 +74,8 @@ func (l Location) validate() error {
 			if from, err := GetPathRelativeToConfig(path); err != nil {
 				return err
 			} else {
-				if stat, err := os.Stat(from); err != nil {
+				if _, err := os.Stat(from); err != nil {
 					return err
-				} else {
-					if !stat.IsDir() {
-						return fmt.Errorf("\"%s\" is not valid directory for location \"%s\"", from, l.name)
-					}
 				}
 			}
 		}


### PR DESCRIPTION
Fix #193 
We only run a stat on the path to check there is no error, this will allow to backup single file and will throw an error if the file doesn't exist for example.