### PR TITLE
Add forget for copy backend

### DIFF
--- a/internal/location.go
+++ b/internal/location.go
@@ -320,7 +320,12 @@ after:
 func (l Location) Forget(prune bool, dry bool) error {
 	colors.PrimaryPrint("Forgetting for location \"%s\"", l.name)
 
-	for _, to := range l.To {
+	backendsToForget := l.To
+	for _, copyBackends := range l.CopyOption {
+		backendsToForget = append(backendsToForget, copyBackends...)
+	}
+
+	for _, to := range backendsToForget {
 		backend, _ := GetBackend(to)
 		colors.Secondary.Printf("For backend \"%s\"\n", backend.name)
 		env, err := backend.getEnv()


### PR DESCRIPTION
fix #221
I only merged the `To` array of the location and the different arrays of `CopyOption`