### PR TITLE
Use restic & rclone binary of host system in docker container

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -21,6 +21,10 @@ func CheckIfResticIsCallable() bool {
 	return CheckIfCommandIsCallable(flags.RESTIC_BIN)
 }
 
+func GetResticPath() (result string, err error) {
+	return exec.LookPath(flags.RESTIC_BIN)
+}
+
 type ExecuteOptions struct {
 	Command string
 	Envs    map[string]string


### PR DESCRIPTION
## The issue

Autorestic calls restic in a container for backing up docker volumes. The restic binary in the container, however, is shipped with the image. This can lead to version mismatches and a very tight coupling between restic & autorestic

## The fix

With this change, Autorestic mounts the restic and optionally the rclone binary from the host OS. This is only possible, because restic and rclone both are Go applications that tend to have almost no external dependencies.
In fact, both [rclone](https://pkgs.alpinelinux.org/package/v3.16/community/x86_64/rclone) and [restic](https://pkgs.alpinelinux.org/package/v3.16/community/x86_64/restic) have no external dependencies other than muslc.

I tried this locally and this approach worked just fine.


Remarks:
- I don't know if the autorestic docker image is still needed after this PR. I just left the Dockerfile as is, to not break anything
- This approach currently doesn't work with a custom rclone path. This, however, was already the case before due to [this call](https://github.com/cupcakearmy/autorestic/blob/6990bf6adc200e7e5a38e76e8f07c4060d3650f1/internal/backend.go#L184)