### PR TITLE
Adds command line flag to override docker image.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&flags.CI, "ci", false, "CI mode disabled interactive mode and colors and enables verbosity")
 	rootCmd.PersistentFlags().BoolVarP(&flags.VERBOSE, "verbose", "v", false, "verbose mode")
 	rootCmd.PersistentFlags().StringVar(&flags.RESTIC_BIN, "restic-bin", "restic", "specify custom restic binary")
+	rootCmd.PersistentFlags().StringVar(&flags.DOCKER_IMAGE, "docker-image", "cupcakearmy/autorestic:"+internal.VERSION, "specify a custom docker image")
 	cobra.OnInitialize(initConfig)
 }
 

--- a/internal/backend.go
+++ b/internal/backend.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cupcakearmy/autorestic/internal/colors"
+	"github.com/cupcakearmy/autorestic/internal/flags"
 )
 
 type BackendRest struct {
@@ -160,7 +161,6 @@ func (b Backend) ExecDocker(l Location, args []string) (int, string, error) {
 	args = append([]string{"restic"}, args...)
 	docker := []string{
 		"run", "--rm",
-		"--pull", "always",
 		"--entrypoint", "ash",
 		"--workdir", dir,
 		"--volume", volume + ":" + dir,
@@ -194,6 +194,7 @@ func (b Backend) ExecDocker(l Location, args []string) (int, string, error) {
 	for key, value := range env {
 		docker = append(docker, "--env", key+"="+value)
 	}
-	docker = append(docker, "cupcakearmy/autorestic:"+VERSION, "-c", strings.Join(args, " "))
+
+	docker = append(docker, flags.DOCKER_IMAGE, "-c", strings.Join(args, " "))
 	return ExecuteCommand(options, docker...)
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -5,4 +5,5 @@ var (
 	VERBOSE    bool = false
 	CRON_LEAN  bool = false
 	RESTIC_BIN string
+	DOCKER_IMAGE string
 )


### PR DESCRIPTION
Adds a command line flag so that the default docker image can be overridden. This is to handle the case when the built docker image has a different version of restic from the host os installation.
Also removed the option to always pull the image - I wasn't sure why that was being done and it adds some overhead to the process. The image version should uniquely identify the image and it would be cached.
