### PR TITLE
Update forget.md keep-within argument to be '14d'

### DIFF
--- a/docs/markdown/location/forget.md
+++ b/docs/markdown/location/forget.md
@@ -21,7 +21,7 @@ locations:
         keep-weekly: 1 # keep 1 last weekly snapshots
         keep-monthly: 12 # keep 12 last monthly snapshots
         keep-yearly: 7 # keep 7 last yearly snapshots
-        keep-within: '2w' # keep snapshots from the last 2 weeks
+        keep-within: '14d' # keep snapshots from the last 14 days
 ```
 
 ## Globally


### PR DESCRIPTION
keep-within duration can only have units 'y', 'm', 'd', and 'h'. The current documentation of '2w' yields:
```invalid argument "2w" for "--keep-within" flag: invalid unit 'w' found after number 2```

https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy