### PR TITLE
add more architectures for linux build process

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -19,7 +19,7 @@ var DIR, _ = filepath.Abs("./dist")
 var targets = map[string][]string{
 	"darwin":  {"amd64", "arm64"},
 	"freebsd": {"386", "amd64", "arm"},
-	"linux":   {"386", "amd64", "arm", "arm64"},
+	"linux":   {"386", "amd64", "arm", "arm64", "ppc64le", "mips", "mipsle", "mips64", "mips64le"},
 	"netbsd":  {"386", "amd64"},
 	"openbsd": {"386", "amd64"},
 }

--- a/build/build.go
+++ b/build/build.go
@@ -17,11 +17,14 @@ import (
 var DIR, _ = filepath.Abs("./dist")
 
 var targets = map[string][]string{
+	// "aix":     {"ppc64"}, // Not supported by fsnotify
 	"darwin":  {"amd64", "arm64"},
 	"freebsd": {"386", "amd64", "arm"},
-	"linux":   {"386", "amd64", "arm", "arm64", "ppc64le", "mips", "mipsle", "mips64", "mips64le"},
+	"linux":   {"386", "amd64", "arm", "arm64", "ppc64le", "mips", "mipsle", "mips64", "mips64le", "s390x"},
 	"netbsd":  {"386", "amd64"},
 	"openbsd": {"386", "amd64"},
+	// "windows": {"386", "amd64"}, // Not supported by autorestic
+	"solaris": {"amd64"},
 }
 
 type buildOptions struct {


### PR DESCRIPTION
equivalent to https://github.com/restic/restic/blob/7d665fa1f4bc8714ffb11da9cf568b4861ab1478/helpers/build-release-binaries/main.go