### PR TITLE
docs: add `dbrennand.autorestic` role

### DIFF
--- a/docs/markdown/community.md
+++ b/docs/markdown/community.md
@@ -8,5 +8,6 @@ A list of community driven projects. (No official affiliation)
 - Ansible Role: <https://github.com/ItsNotGoodName/ansible-role-autorestic>
 - Ansible Role: <https://github.com/FuzzyMistborn/ansible-role-autorestic>
 - Ansible Role: <https://0xacab.org/varac-projects/ansible-role-autorestic>
+- Ansible Role: <https://github.com/dbrennand/ansible-role-autorestic>
 
 > :ToCPrevNext


### PR DESCRIPTION
Add [dbrennand.autorestic](https://github.com/dbrennand/ansible-role-autorestic) Ansible role to community page. Also available on Ansible Galaxy: https://galaxy.ansible.com/dbrennand/autorestic