### PR TITLE
Use options on exec command

### DIFF
--- a/internal/backend.go
+++ b/internal/backend.go
@@ -143,6 +143,7 @@ func (b Backend) Exec(args []string) error {
 		return err
 	}
 	options := ExecuteOptions{Envs: env}
+	args = append(args, combineBackendOptions("exec", b)...)
 	_, out, err := ExecuteResticCommand(options, args...)
 	if err != nil {
 		colors.Error.Println(out)


### PR DESCRIPTION
fix #252 
This PR just add the required line to combine the exec command with backend options.