### PR TITLE
Allow env variables in path for rest backend

### DIFF
--- a/internal/backend.go
+++ b/internal/backend.go
@@ -38,7 +38,7 @@ func (b Backend) generateRepo() (string, error) {
 	case "local":
 		return GetPathRelativeToConfig(b.Path)
 	case "rest":
-		parsed, err := url.Parse(b.Path)
+		parsed, err := url.Parse(os.ExpandEnv(b.Path))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Hi, this commit enables env variables for the rest backend.

For the restic [rest-server](https://github.com/restic/rest-server) it isn't possible to hide the password in the autorestic config file behind a env variable, although [rest-server](https://github.com/restic/rest-server) supports this feature. This results in writing the password in clear text into the config file.

This change enables env vars like `$var` and `${var}` to be replaced by autorestic. You can then add your password in the config file like so:
``` yml
backends:
  rest:
    type: rest
    path: http://restic:${RESTIC_PASSWORD}@restic_server:8000
```
or
``` yml
backends:
  rest:
    type: rest
    path: http://restic_server:8000
    rest:
      user: restic
      password: ${RESTIC_PASSWORD}
```

Maybe a note in the documentation is helpful.