### PR TITLE
Fix empty ADDED_SIZE env for restic>=0.14.0

### DIFF
--- a/internal/metadata/extractor_added.go
+++ b/internal/metadata/extractor_added.go
@@ -14,9 +14,9 @@ func (e addedExtractor) Matches(line string) bool {
 }
 func (e addedExtractor) Extract(metadata *BackupLogMetadata, line string) {
 	// Sample line: "Added to the repo: 0 B"
-	metadata.AddedSize = strings.TrimSpace(e.re.ReplaceAllString(line, ""))
+	metadata.AddedSize = strings.TrimSpace(e.re.ReplaceAllString(line, "$2"))
 }
 
 func NewAddedExtractor() MetadatExtractor {
-	return addedExtractor{regexp.MustCompile(`(?i)^Added to the repo:`)}
+	return addedExtractor{regexp.MustCompile(`(?i)^Added to the repo(sitory)?: ([\d\.]+ \w+)( \([\d\.]+[\w\s]+\))?`)}
 }


### PR DESCRIPTION
Since version 0.14.0 restic changed string for summary of backup, current version:
```go
	b.P("%s to the repository: %-5s (%-5s stored)\n", verb,
		ui.FormatBytes(summary.ItemStats.DataSize+summary.ItemStats.TreeSize),
		ui.FormatBytes(summary.ItemStats.DataSizeInRepo+summary.ItemStats.TreeSizeInRepo))
```
https://github.com/restic/restic/blob/master/internal/ui/backup/text.go#L137-L139

old version (prior 0.13.1):
```go
	b.P("%s to the repo: %-5s\n", verb, formatBytes(summary.ItemStats.DataSize+summary.ItemStats.TreeSize))
```
https://github.com/restic/restic/blob/v0.13.1/internal/ui/backup/text.go#L181


This MR is fixing issue of empty `AUTORESTIC_ADDED_SIZE` env variables for new restic versions and should work for old ones as well.
![regex101](https://user-images.githubusercontent.com/552506/213203900-96204220-b87d-44d2-9b85-6ddcd02e39fd.png)
