### PR TITLE
Update cron.md

### DIFF
--- a/docs/markdown/location/cron.md
+++ b/docs/markdown/location/cron.md
@@ -37,7 +37,7 @@ Then paste this at the bottom of the file and save it. Note that in this specifi
 PATH="/usr/local/bin:/usr/bin:/bin"
 
 # Example running every 5 minutes
-*/5 * * * * autorestic -c /path/to/my/.autorestic.yml --ci cron
+*/5 * * * * root autorestic -c /path/to/my/.autorestic.yml --ci cron
 ```
 
 > The `--ci` option is not required, but recommended
@@ -45,7 +45,7 @@ PATH="/usr/local/bin:/usr/bin:/bin"
 To debug a cron job you can use
 
 ```bash
-*/5 * * * * autorestic -c /path/to/my/.autorestic.yml --ci cron > /tmp/autorestic.log 2>&1
+*/5 * * * * root autorestic -c /path/to/my/.autorestic.yml --ci cron > /tmp/autorestic.log 2>&1
 ```
 
 Now you can add as many `cron` attributes as you wish in the config file ⏱


### PR DESCRIPTION
crontab entries need a user. 
When copying and pasting the examples directly into my crontab, they were not running. Using a crontab checking utility, an error was generated:

 `Checking correctness of /var/spool/cron/crontabs/root `

`*/5 * * * * /usr/local/bin/autorestic -v -c /root/.autorestic.yml --ci cron |& /usr/bin/logger -t autorestic > /dev/null 2>&1`
`
e:    INVALID_USER: Invalid username "/usr/local/bin/autorestic"
E: There were 1 errors and 0 warnings.`

This update adds a username (root) to the example, which fixes the syntax error.