### PR TITLE
Use Printf instead of Println

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 		viper.AutomaticEnv()
 		if viper.ConfigFileUsed() == "" {
-			colors.Error.Println("cannot read config file %s\n", cfgFile)
+			colors.Error.Printf("cannot read config file %s\n", cfgFile)
 			os.Exit(1)
 		}
 	} else {


### PR DESCRIPTION
Testing in Fedora reports:

./root.go:58:4: (*github.com/fatih/color.Color).Println call has possible Printf formatting directive %s