### PR TITLE
Update restic to 0.16.0 and fix ARM compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN go build
 
-FROM restic/restic:0.15.1
+FROM restic/restic:0.16.0
 RUN apk add --no-cache rclone bash
 COPY --from=builder /app/autorestic /usr/bin/autorestic
 ENTRYPOINT []


### PR DESCRIPTION
Starting with 0.16.0, the Restic Docker image is ARM compatible. Therefore, this PR fixes #298.