### PR TITLE
Bump version in config.go to 1.7.9

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const VERSION = "1.7.7"
+const VERSION = "1.7.9"
 
 type OptionMap map[string][]interface{}
 type Options map[string]OptionMap


### PR DESCRIPTION
@cupcakearmy  Seems like you forgot bumping the version in `config.go` in the last release. Amongst other things, this leads to the wrong filenames in the [release](https://github.com/cupcakearmy/autorestic/releases). Unfortunately, this breaks my Ansible workflow :) 

In my opinion, there is no point in retroactively fixing this in 1.7.8, since the release is already out of the door and swapping the binaries with fixed ones would create confusion and worse reproducability. Therefore, I bumped the version straight to 1.7.9.

Btw: You could help me out by adding the label [hacktoberfest-accepted](https://hacktoberfest.com/participation/#pr-mr-details) to this PR ;) 