### PR TITLE
fix: cli command to unlock the autorestic running value

### DIFF
--- a/cmd/unlock.go
+++ b/cmd/unlock.go
@@ -20,7 +20,9 @@ To check you can run "ps aux | grep autorestic".`,
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.GetConfig()
 
-		if isAutoresticRunning() {
+		force, _ := cmd.Flags().GetBool("force")
+
+		if !force && isAutoresticRunning() {
 			colors.Error.Print("Another autorestic instance is running. Are you sure you want to unlock? (yes/no): ")
 			var response string
 			fmt.Scanln(&response)
@@ -42,6 +44,7 @@ To check you can run "ps aux | grep autorestic".`,
 
 func init() {
 	rootCmd.AddCommand(unlockCmd)
+	unlockCmd.Flags().Bool("force", false, "force unlock")
 }
 
 // isAutoresticRunning checks if autorestic is running

--- a/cmd/unlock.go
+++ b/cmd/unlock.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/cupcakearmy/autorestic/internal"
+	"github.com/cupcakearmy/autorestic/internal/colors"
+	"github.com/cupcakearmy/autorestic/internal/lock"
+	"github.com/spf13/cobra"
+)
+
+var unlockCmd = &cobra.Command{
+	Use:   "unlock",
+	Short: "Unlock autorestic only if you are sure that no other instance is running (ps aux | grep autorestic)",
+	Long: `Unlock autorestic only if you are sure that no other instance is running.
+To check you can run "ps aux | grep autorestic".`,
+	Run: func(cmd *cobra.Command, args []string) {
+		internal.GetConfig()
+		err := lock.Unlock()
+		if err != nil {
+			colors.Error.Println("Could not unlock:", err)
+			return
+		}
+
+		colors.Success.Println("Unlock successful")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(unlockCmd)
+}

--- a/cmd/unlock.go
+++ b/cmd/unlock.go
@@ -1,6 +1,11 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
 	"github.com/cupcakearmy/autorestic/internal"
 	"github.com/cupcakearmy/autorestic/internal/colors"
 	"github.com/cupcakearmy/autorestic/internal/lock"
@@ -9,11 +14,22 @@ import (
 
 var unlockCmd = &cobra.Command{
 	Use:   "unlock",
-	Short: "Unlock autorestic only if you are sure that no other instance is running (ps aux | grep autorestic)",
+	Short: "Unlock autorestic only if you are sure that no other instance is running",
 	Long: `Unlock autorestic only if you are sure that no other instance is running.
 To check you can run "ps aux | grep autorestic".`,
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.GetConfig()
+
+		if isAutoresticRunning() {
+			colors.Error.Print("Another autorestic instance is running. Are you sure you want to unlock? (yes/no): ")
+			var response string
+			fmt.Scanln(&response)
+			if strings.ToLower(response) != "yes" {
+				colors.Primary.Println("Unlocking aborted.")
+				return
+			}
+		}
+
 		err := lock.Unlock()
 		if err != nil {
 			colors.Error.Println("Could not unlock:", err)
@@ -26,4 +42,35 @@ To check you can run "ps aux | grep autorestic".`,
 
 func init() {
 	rootCmd.AddCommand(unlockCmd)
+}
+
+// isAutoresticRunning checks if autorestic is running
+// and returns true if it is.
+// It also prints the processes to stdout.
+func isAutoresticRunning() bool {
+	cmd := exec.Command("sh", "-c", "ps aux | grep autorestic")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return false
+	}
+
+	lines := strings.Split(out.String(), "\n")
+	autoresticProcesses := []string{}
+
+	for _, line := range lines {
+		if strings.Contains(line, "autorestic") && !strings.Contains(line, "grep autorestic") {
+			autoresticProcesses = append(autoresticProcesses, line)
+		}
+	}
+
+	if len(autoresticProcesses) > 0 {
+		colors.Faint.Println("Found autorestic processes:")
+		for _, proc := range autoresticProcesses {
+			colors.Faint.Println(proc)
+		}
+		return true
+	}
+	return false
 }

--- a/docs/pages/cli/unlock.md
+++ b/docs/pages/cli/unlock.md
@@ -1,0 +1,26 @@
+# Unlock
+
+In case autorestic throws the error message `an instance is already running. exiting`, but there is no instance running you can unlock the lock.
+
+To verify that there is no instance running you can use `ps aux | grep autorestic`.
+
+Example with no instance running:
+
+```bash
+> ps aux | grep autorestic
+root       39260  0.0  0.0   6976  2696 pts/11   S+   19:41   0:00 grep autorestic
+```
+
+Example with an instance running:
+
+```bash
+> ps aux | grep autorestic
+root       29465  0.0  0.0 1162068 7380 pts/7    Sl+  19:28   0:00 autorestic --ci backup -a
+root       39260  0.0  0.0   6976  2696 pts/11   S+   19:41   0:00 grep autorestic
+```
+
+**If an instance is running you should not unlock as it could lead to data loss!**
+
+```bash
+autorestic unlock
+```

--- a/docs/pages/cli/unlock.md
+++ b/docs/pages/cli/unlock.md
@@ -24,3 +24,9 @@ root       39260  0.0  0.0   6976  2696 pts/11   S+   19:41   0:00 grep autorest
 ```bash
 autorestic unlock
 ```
+
+Use the `--force` to prevent the confirmation prompt if an instance is running.
+
+```bash
+autorestic unlock --force
+```


### PR DESCRIPTION
Hi, thanks for the awesome tool.

I had the case where the `.autorestic.lock.yml` had the `running` key to `true` but there was no instance running.

This pull request adds the `unlock` command which just unlocks. Additionally a page to the documentation is added.

Example:

```bash
❯ go run main.go unlock
Using config:    /home/user/.autorestic.yaml
Using lock:      /home/user/.autorestic.lock.yml
Unlock successful
❯ cat ~/.autorestic.lock.yml | grep running
running: false
```

I don't know if "fix:" is the right commit, I can rewrite the commit with "feat:" in case it fits better.