### PR TITLE
do not replace all shell paths in the example

### DIFF
--- a/docs/pages/location/cron.md
+++ b/docs/pages/location/cron.md
@@ -34,7 +34,7 @@ Then paste this at the bottom of the file and save it. Note that in this specifi
 
 ```bash
 # This is required, as it otherwise cannot find restic as a command.
-PATH="/usr/local/bin:/usr/bin:/bin"
+PATH="/usr/local/bin:$PATH"
 
 # Example running every 5 minutes
 */5 * * * * autorestic -c /path/to/my/.autorestic.yml --ci cron


### PR DESCRIPTION
Current example doesn't utilize already defined paths that can be distro specific (i.e. /sbin /usr/sbin on Debian).

Proposed solution appends /usr/local/bin while keeping other paths to be processed next.