### PR TITLE
feat: add the ability to backup docker volumes from docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN go build
 
 FROM restic/restic:0.16.0
-RUN apk add --no-cache rclone bash
+RUN apk add --no-cache rclone bash docker-cli
 COPY --from=builder /app/autorestic /usr/bin/autorestic
 ENTRYPOINT []
 CMD [ "autorestic" ]


### PR DESCRIPTION
## Background
When building my `autorestic` backup I wanted to avoid installing `autorestic` locally - this is because I want to avoid manual setups in case I move to a new host.

## Problem
I wanted to backup my docker volumes from inside the `autorestic` docker container.
It was not possible with the stock image due to lack of the `docker-cli` package.

## Changes
- Added `docker-cli` package.

## Example:
```yml
# docker-compose.yml
# docker compose run backup
version: "2.1"

services:
  backup:
    image: cupcakearmy/autorestic
    volumes:
      # Docker socket to backup volumes
      - /var/run/docker.sock:/var/run/docker.sock
      # AutoRestic config
      - ./.autorestic.yaml:/.autorestic.yaml
    # Run backup
    entrypoint: ["autorestic", "backup", "--ci", "-va", "-c", "/.autorestic.yaml"]
```

```yml
version: 2

global:
  # ...

locations:
  docker_volumes:
    from:
      - volume_example
    type: volume
    to: remote

backends:
  remote:
    # ...
```

## Related Issues:
- Resolves #334