### PR TITLE
Fix quick installation instruction

### DIFF
--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -5,7 +5,7 @@ Linux & macOS. Windows is not supported. If you have problems installing please 
 Autorestic requires `bash`, `wget` and `bzip2` to be installed. For most systems these should be already installed.
 
 ```bash
-wget -qO - https://raw.githubusercontent.com/cupcakearmy/autorestic/master/install.sh | bash
+sudo bash -c "$(wget -qO - https://raw.githubusercontent.com/cupcakearmy/autorestic/master/install.sh)"
 ```
 
 ## Alternatives


### PR DESCRIPTION
The command in the documentation was wrong and didn't run the script with elevated privileges as mentioned in #308.