### PR TITLE
Fix default value of `XDG_CONFIG_HOME` in config path resolution

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,24 +59,7 @@ func initConfig() {
 			os.Exit(1)
 		}
 	} else {
-		configPaths := []string{"."}
-
-		// Home
-		if home, err := homedir.Dir(); err == nil {
-			configPaths = append(configPaths, home)
-		}
-
-		// XDG_CONFIG_HOME
-		{
-			prefix, found := os.LookupEnv("XDG_CONFIG_HOME")
-			if !found {
-				if home, err := homedir.Dir(); err != nil {
-					prefix = filepath.Join(home, ".config")
-				}
-			}
-			xdgConfig := filepath.Join(prefix, "autorestic")
-			configPaths = append(configPaths, xdgConfig)
-		}
+		configPaths := getConfigPaths()
 		for _, cfgPath := range configPaths {
 			viper.AddConfigPath(cfgPath)
 		}
@@ -87,4 +70,23 @@ func initConfig() {
 		viper.SetConfigName(cfgFileName)
 		viper.AutomaticEnv()
 	}
+}
+
+func getConfigPaths() []string {
+	result := []string{"."}
+	if home, err := homedir.Dir(); err == nil {
+		result = append(result, home)
+	}
+
+	{
+		xdgConfigHome, found := os.LookupEnv("XDG_CONFIG_HOME")
+		if !found {
+			if home, err := homedir.Dir(); err == nil {
+				xdgConfigHome = filepath.Join(home, ".config")
+			}
+		}
+		xdgConfig := filepath.Join(xdgConfigHome, "autorestic")
+		result = append(result, xdgConfig)
+	}
+	return result
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/mitchellh/go-homedir"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+const xdgConfigHome = "XDG_CONFIG_HOME"
+
+func assertContains(t *testing.T, array []string, element string) {
+	if !slices.Contains(array, element) {
+		t.Errorf("Expected %s to be contained in %s", element, array)
+	}
+}
+
+func TestConfigResolving(t *testing.T) {
+	t.Run("~/.config/autorestic is used if XDG_CONFIG_HOME is not set", func(t *testing.T) {
+		// Override env using testing so that env gets restored after test
+		t.Setenv(xdgConfigHome, "")
+		_ = os.Unsetenv("XDG_CONFIG_HOME")
+		configPaths := getConfigPaths()
+		homeDir, _ := homedir.Dir()
+		expectedConfigPath := filepath.Join(homeDir, ".config/autorestic")
+		assertContains(t, configPaths, expectedConfigPath)
+	})
+
+	t.Run("XDG_CONFIG_HOME is respected if set", func(t *testing.T) {
+		t.Setenv(xdgConfigHome, "/foo/bar")
+
+		configPaths := getConfigPaths()
+		assertContains(t, configPaths, filepath.Join("/", "foo", "bar", "autorestic"))
+	})
+}

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -2,10 +2,11 @@
 
 ## Path
 
-By default autorestic searches for a `.autorestic.yml` file in the current directory and your home folder.
+By default autorestic searches for a `.autorestic.yml` file in the current directory, your home folder and your XDG config folder (`~/.config/` by default):
 
 - `./.autorestic.yml`
 - `~/.autorestic.yml`
+- `~/.config/autorestic/.autorestic.yml`
 
 You can also specify a custom file with the `-c path/to/some/config.yml`
 


### PR DESCRIPTION
A seemingly undocumented feature of autorestic is, that config files are loaded from `$XDG_CONFIG_HOME/.config/autorestic` by default. The code suggests, that the default value for `$XDG_CONFIG_HOME` is supposed to be `~/.config/`. 

Unfortunately, the code had a minor bug that lead to the default being `~`.

This PR fixes this bug, adds a few tests and mentions this feature in the documentation.

This is my first Go code, so please give feedback where needed :) 