### PR TITLE
Add PreValidate hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Autorestic is a wrapper around the amazing [restic](https://restic.net/). While 
 - Backup locations to multiple backends
 - Snapshot policies and pruning
 - Fully encrypted
-- Pre/After hooks
+- Before/after backup hooks
 - Exclude pattern/files
 - Cron jobs for automatic backup
 - Backup & Restore docker volume

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -56,6 +56,8 @@ version: 2
 
 extras:
   hooks: &foo
+    prevalidate:
+      - echo "Wake up!"
     before:
       - echo "Hello"
     after:

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -13,7 +13,7 @@ Autorestic is a wrapper around the amazing [restic](https://restic.net/). While 
 - Backup locations to multiple backends
 - Snapshot policies and pruning
 - Fully encrypted
-- Pre/After hooks
+- Before/after backup hooks
 - Exclude pattern/files
 - Cron jobs for automatic backup
 - Backup & Restore docker volumes

--- a/docs/pages/location/hooks.md
+++ b/docs/pages/location/hooks.md
@@ -6,10 +6,13 @@ They consist of a list of commands that will be executed in the same directory a
 
 The following hooks groups are supported, none are required:
 
+- `prevalidate`
 - `before`
 - `after`
 - `failure`
 - `success`
+
+The difference between `prevalidate` and `before` hooks are that `prevalidate` is run before checking the backup location is valid, including checking that the `from` directories exist. This can be useful, for example, to mount the source filesystem that contains the directories listed in `from`.
 
 ```yml | .autorestic.yml
 locations:
@@ -17,12 +20,14 @@ locations:
     from: /data
     to: my-backend
     hooks:
+      prevalidate:
+        - echo "Checks"
       before:
         - echo "One"
         - echo "Two"
         - echo "Three"
       after:
-        - echo "Byte"
+        - echo "Bye"
       failure:
         - echo "Something went wrong"
       success:
@@ -31,13 +36,15 @@ locations:
 
 ## Flowchart
 
-1. `before` hook
-2. Run backup
-3. `after` hook
-4. - `success` hook if no errors were found
+1. `prevalidate` hook
+2. Check backup location
+3. `before` hook
+4. Run backup
+5. `after` hook
+6. - `success` hook if no errors were found
    - `failure` hook if at least one error was encountered
 
-If the `before` hook encounters errors the backup and `after` hooks will be skipped and only the `failed` hooks will run.
+If either the `prevalidate` or `before` hook encounters errors then the backup and `after` hooks will be skipped and only the `failed` hooks will run.
 
 ## Environment variables
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -132,10 +132,11 @@ func (c *Config) Describe() {
 
 		tmp = ""
 		hooks := map[string][]string{
-			"Before":  l.Hooks.Before,
-			"After":   l.Hooks.After,
-			"Failure": l.Hooks.Failure,
-			"Success": l.Hooks.Success,
+			"PreValidate": l.Hooks.PreValidate,
+			"Before":      l.Hooks.Before,
+			"After":       l.Hooks.After,
+			"Failure":     l.Hooks.Failure,
+			"Success":     l.Hooks.Success,
 		}
 		for hook, commands := range hooks {
 			if len(commands) > 0 {


### PR DESCRIPTION
Fix #332.

This adds a new "PreValidate" hook that is executed before checking the backup location. This allows, for example, mounting a remote source to make the directories of the location available.

"PreValidate" is added as a new hook to avoid any breakage that might have been caused by changing the behaviour of the "before" hook.

Documentataion updates included.