### PR TITLE
fix(unlock cmd): ignore process if its the current id

### DIFF
--- a/cmd/unlock.go
+++ b/cmd/unlock.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -61,9 +62,10 @@ func isAutoresticRunning() bool {
 
 	lines := strings.Split(out.String(), "\n")
 	autoresticProcesses := []string{}
+	currentPid := fmt.Sprint(os.Getpid())
 
 	for _, line := range lines {
-		if strings.Contains(line, "autorestic") && !strings.Contains(line, "grep autorestic") {
+		if strings.Contains(line, "autorestic") && !strings.Contains(line, "grep autorestic") && !strings.Contains(line, currentPid) {
 			autoresticProcesses = append(autoresticProcesses, line)
 		}
 	}


### PR DESCRIPTION
Hi, as [@bin101 wrote](https://github.com/cupcakearmy/autorestic/pull/329#issuecomment-1991839706) in #329 there is a warning when using `autorestic unlock` because of the current running process which also has `autorestic` in its name. Maybe I only tested it with `go run`....

This fix adds: Ignoring the current process id, to avoid prompting that the current process is running.