### PR TITLE
Allow REST backend with docker volumes

### DIFF
--- a/internal/backend.go
+++ b/internal/backend.go
@@ -183,6 +183,7 @@ func (b Backend) ExecDocker(l Location, args []string) (int, string, error) {
 	case "s3":
 	case "azure":
 	case "gs":
+	case "rest":
 		// No additional setup needed
 	case "rclone":
 		// Read host rclone config and mount it into the container


### PR DESCRIPTION
Simple change to allow REST backend when backing up Docker volumes.

Close #365.

The generated docker command:
```
/usr/bin/docker run --rm --entrypoint ash --workdir /data --volume <redacted>:/data --hostname <redacted> --env RESTIC_REPOSITORY=rest:http://<redacted> --env RESTIC_PASSWORD=<redacted> cupcakearmy/autorestic:1.8.1 -c restic backup --dry-run --tag ar:location:<redacted>/data
```