### PR TITLE
When reading backend config values from environment variables treat all special characters in backend name as `_`

### DIFF
--- a/internal/backend.go
+++ b/internal/backend.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/cupcakearmy/autorestic/internal/colors"
@@ -57,6 +58,8 @@ func (b Backend) generateRepo() (string, error) {
 	}
 }
 
+var nonAlphaRegex = regexp.MustCompile("[^A-Za-z0-9]")
+
 func (b Backend) getEnv() (map[string]string, error) {
 	env := make(map[string]string)
 	// Key
@@ -72,7 +75,9 @@ func (b Backend) getEnv() (map[string]string, error) {
 	}
 
 	// From Envfile and passed as env
-	var prefix = "AUTORESTIC_" + strings.ToUpper(b.name) + "_"
+	nameForEnv := strings.ToUpper(b.name)
+	nameForEnv = nonAlphaRegex.ReplaceAllString(nameForEnv, "_")
+	var prefix = "AUTORESTIC_" + nameForEnv + "_"
 	for _, variable := range os.Environ() {
 		var splitted = strings.SplitN(variable, "=", 2)
 		if strings.HasPrefix(splitted[0], prefix) {

--- a/internal/backend_test.go
+++ b/internal/backend_test.go
@@ -194,6 +194,33 @@ func TestGetEnv(t *testing.T) {
 		assertEqual(t, result["B2_ACCOUNT_ID"], "foo123")
 		assertEqual(t, result["B2_ACCOUNT_KEY"], "foo456")
 	})
+
+	for _, char := range "@-_:/" {
+		t.Run(fmt.Sprintf("env var with special char (%c)", char), func(t *testing.T) {
+			// generate env variables
+			// TODO better way to teardown
+			defer os.Unsetenv("AUTORESTIC_FOO_BAR_RESTIC_PASSWORD")
+			defer os.Unsetenv("AUTORESTIC_FOO_BAR_B2_ACCOUNT_ID")
+			defer os.Unsetenv("AUTORESTIC_FOO_BAR_B2_ACCOUNT_KEY")
+			os.Setenv("AUTORESTIC_FOO_BAR_RESTIC_PASSWORD", "secret123")
+			os.Setenv("AUTORESTIC_FOO_BAR_B2_ACCOUNT_ID", "foo123")
+			os.Setenv("AUTORESTIC_FOO_BAR_B2_ACCOUNT_KEY", "foo456")
+
+			b := Backend{
+				name: fmt.Sprintf("foo%cbar", char),
+				Type: "local",
+				Path: "/foo/bar",
+			}
+			result, err := b.getEnv()
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+			assertEqual(t, result["RESTIC_REPOSITORY"], "/foo/bar")
+			assertEqual(t, result["RESTIC_PASSWORD"], "secret123")
+			assertEqual(t, result["B2_ACCOUNT_ID"], "foo123")
+			assertEqual(t, result["B2_ACCOUNT_KEY"], "foo456")
+		})
+	}
 }
 
 func TestValidate(t *testing.T) {


### PR DESCRIPTION
Related to #202 

This should help in cases where the backend name includes special characters like `-` and trying to set configuration values from environment variables.