### PR TITLE
install.sh: FreeBSD amd64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,8 @@ if [[ $NATIVE_OS == *"linux"* ]]; then
     OS=linux
 elif [[ $NATIVE_OS == *"darwin"* ]]; then
     OS=darwin
+elif [[ $NATIVE_OS == *"freebsd"* ]]; then
+    OS=freebsd
 else
     echo "Could not determine OS automatically, please check the release page manually: https://github.com/cupcakearmy/autorestic/releases"
     exit 1
@@ -17,7 +19,7 @@ fi
 echo $OS
 
 NATIVE_ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
-if [[ $NATIVE_ARCH == *"x86_64"* ]]; then
+if [[ $NATIVE_ARCH == *"x86_64"* || $NATIVE_ARCH == *"amd64"* ]]; then
     ARCH=amd64
 elif [[ $NATIVE_ARCH == *"arm64"* || $NATIVE_ARCH == *"aarch64"* ]]; then
     ARCH=arm64


### PR DESCRIPTION
As a _drive by commiter,_ I want _installer script to work on my janky freebsd vps_ so I can _backups_

# What it does 

- Add freebsd to the NATIVE_OS check
- Add amd64 to the NATIVE_ARCH check

This PR feels a little "got mine", but I don't think it'll hurt anybody else. 

# What I could have done instead
These seem like too much for a drive-by commit 

- generate `install.sh` as part of the release process so it knows which releases are worth trying 
- rewrite the script to check arch within each OS check (since amd64 might not be a good arch choice for linux?)

# Contributor agreement

The patch is yours if you want it, and I don't have to be in the authors/credits/change log etc