### PR TITLE
Add basic CI (build & test) for PRs and master pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.21'
+      - run: go test -v ./...
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.21'
+      - run: go build -v .


### PR DESCRIPTION
While hacking on the tests for a fix, I noticed that they weren't being run during the CI. To help out, I figured the project could make use of a basic CI that runs the tests and builds the code.