### PR TITLE
Add `init` backend config to automatically initialize restic repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,25 @@ on:
   push:
     branches: [master]
 
+env: 
+  RESTIC_VERSION: "0.17.1"
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install restic@${{ env.RESTIC_VERSION }}
+        run: |
+          mkdir -p tools/restic
+          curl --fail --location --silent --show-error --output tools/restic/restic.bz2 \
+            "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2"
+          bzip2 -d tools/restic/restic.bz2
+          chmod +x tools/restic/restic
+          echo "$GITHUB_WORKSPACE/tools/restic" >> "$GITHUB_PATH"
+      - run: restic version
+
       - uses: actions/setup-go@v3
         with:
           go-version: '^1.21'

--- a/cmd/backup_test.go
+++ b/cmd/backup_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func runCmd(t *testing.T, args ...string) error {
+	t.Helper()
+
+	viper.Reset()
+	rootCmd.SetArgs(args)
+
+	err := rootCmd.Execute()
+	return err
+}
+
+func TestBackupCmd(t *testing.T) {
+	workDir := t.TempDir()
+
+	// Prepare content to be backed up
+	locationDir := path.Join(workDir, "my-location")
+	err := os.Mkdir(locationDir, 0750)
+	assert.Nil(t, err)
+	err = os.WriteFile(path.Join(locationDir, "back-me-up.txt"), []byte("hello world"), 0640)
+	assert.Nil(t, err)
+
+	// Write config file
+	config, err := yaml.Marshal(map[string]interface{}{
+		"version": 2,
+		"locations": map[string]map[string]interface{}{
+			"my-location": {
+				"type": "local",
+				"from": []string{locationDir},
+				"to":   []string{"test"},
+			},
+		},
+		"backends": map[string]map[string]interface{}{
+			"test": {
+				"type": "local",
+				"path": path.Join(workDir, "test-backend"),
+				"key":  "supersecret",
+			},
+		},
+	})
+	assert.Nil(t, err)
+	configPath := path.Join(workDir, ".autorestic.yml")
+	err = os.WriteFile(configPath, config, 0640)
+	assert.Nil(t, err)
+
+	// Init repo (not initialized by default)
+	err = runCmd(t, "exec", "--ci", "-a", "-c", configPath, "init")
+	assert.Nil(t, err)
+
+	// Do the backup
+	err = runCmd(t, "backup", "--ci", "-a", "-c", configPath)
+	assert.Nil(t, err)
+
+	// Restore in a separate dir
+	restoreDir := path.Join(workDir, "restore")
+	err = runCmd(t, "restore", "--ci", "-c", configPath, "-l", "my-location", "--to", restoreDir)
+	assert.Nil(t, err)
+
+	// Check restored file
+	restoredContent, err := os.ReadFile(path.Join(restoreDir, locationDir, "back-me-up.txt"))
+	assert.Nil(t, err)
+	assert.Equal(t, "hello world", string(restoredContent))
+}

--- a/docs/pages/backend/index.md
+++ b/docs/pages/backend/index.md
@@ -38,3 +38,19 @@ backends:
 ```
 
 With this setting, if a key is missing, `autorestic` will crash instead of generating a new key and updating your config file.
+
+## Automatic Backend Initialization
+
+`autorestic` is able to automatically initialize backends for you. This is done by setting `init: true` in the config for a given backend. For example:
+
+```yaml | .autorestic.yml
+backend:
+  foo:
+    type: ...
+    path: ...
+    init: true
+```
+
+When you set `init: true` on a backend config, `autorestic` will automatically initialize the underlying `restic` repository that powers the backend if it's not already initialized. In practice, this means that the backend will be initialized the first time it is being backed up to.
+
+This option is helpful in cases where you want to automate the configuration of `autorestic`. This means that instead of running `autorestic exec init -b ...` manually when you create a new backend, you can let `autorestic` initialize it for you.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -35,5 +36,4 @@ require (
 	golang.org/x/text v0.3.8 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/location.go
+++ b/internal/location.go
@@ -222,6 +222,14 @@ func (l Location) Backup(cron bool, specificBackend string) []error {
 			continue
 		}
 
+		if backend.Init {
+			err = backend.EnsureInit()
+			if err != nil {
+				errors = append(errors, err)
+				continue
+			}
+		}
+
 		cmd := []string{"backup"}
 		cmd = append(cmd, combineAllOptions("backup", l, backend)...)
 		if cron {


### PR DESCRIPTION
This PR adds a new `init` option to the backend config. Setting `init: true` on a backend makes it so that `autorestic` will automatically initialize the `restic` repository that powers that backend.

This initialization is done in a lazy fashion. If the repository is already initialized nothing will happen.

The initialization process will happen when a backup is triggered through:
- `autorestic backup ...`
- `autorestic cron` (the initialization happens only when the backup happens, not during each invocation of the cron handler)

Note that I've updated `autorestic check` to keep its auto-init behavior but to rely on the new implementation for this PR.

Checking if a repo exists is done by calling `restic cat config` as documented in https://restic.readthedocs.io/en/latest/075_scripting.html#check-if-a-repository-is-already-initialized. I chose this method over the existing method of calling `restic check` because this method performs fewer IO operations on the repository. This matters in cases where the repo is stored on a cloud platform where these IO operations turn into API calls which end up costing money for the user. 