### PR TITLE
Fix `forgetoption` and `configoption` when saving the config file

### DIFF
--- a/internal/backend.go
+++ b/internal/backend.go
@@ -14,19 +14,19 @@ import (
 )
 
 type BackendRest struct {
-	User     string `mapstructure:"user,omitempty"`
-	Password string `mapstructure:"password,omitempty"`
+	User     string `mapstructure:"user,omitempty" yaml:"user,omitempty"`
+	Password string `mapstructure:"password,omitempty" yaml:"password,omitempty"`
 }
 
 type Backend struct {
 	name       string
-	Type       string            `mapstructure:"type,omitempty"`
-	Path       string            `mapstructure:"path,omitempty"`
-	Key        string            `mapstructure:"key,omitempty"`
-	RequireKey bool              `mapstructure:"requireKey,omitempty"`
-	Env        map[string]string `mapstructure:"env,omitempty"`
-	Rest       BackendRest       `mapstructure:"rest,omitempty"`
-	Options    Options           `mapstructure:"options,omitempty"`
+	Type       string            `mapstructure:"type,omitempty" yaml:"type,omitempty"`
+	Path       string            `mapstructure:"path,omitempty" yaml:"path,omitempty"`
+	Key        string            `mapstructure:"key,omitempty" yaml:"key,omitempty"`
+	RequireKey bool              `mapstructure:"requireKey,omitempty" yaml:"requireKey,omitempty"`
+	Env        map[string]string `mapstructure:"env,omitempty" yaml:"env,omitempty"`
+	Rest       BackendRest       `mapstructure:"rest,omitempty" yaml:"rest,omitempty"`
+	Options    Options           `mapstructure:"options,omitempty" yaml:"options,omitempty"`
 }
 
 func GetBackend(name string) (Backend, bool) {

--- a/internal/config.go
+++ b/internal/config.go
@@ -23,11 +23,11 @@ type OptionMap map[string][]interface{}
 type Options map[string]OptionMap
 
 type Config struct {
-	Version   string              `mapstructure:"version"`
-	Extras    interface{}         `mapstructure:"extras"`
-	Locations map[string]Location `mapstructure:"locations"`
-	Backends  map[string]Backend  `mapstructure:"backends"`
-	Global    Options             `mapstructure:"global"`
+	Version   string              `mapstructure:"version" yaml:"version"`
+	Extras    interface{}         `mapstructure:"extras" yaml:"extras"`
+	Locations map[string]Location `mapstructure:"locations" yaml:"locations"`
+	Backends  map[string]Backend  `mapstructure:"backends" yaml:"backends"`
+	Global    Options             `mapstructure:"global" yaml:"global"`
 }
 
 var once sync.Once

--- a/internal/location.go
+++ b/internal/location.go
@@ -33,26 +33,26 @@ const (
 )
 
 type Hooks struct {
-	Dir         string    `mapstructure:"dir"`
-	PreValidate HookArray `mapstructure:"prevalidate,omitempty"`
-	Before      HookArray `mapstructure:"before,omitempty"`
-	After       HookArray `mapstructure:"after,omitempty"`
-	Success     HookArray `mapstructure:"success,omitempty"`
-	Failure     HookArray `mapstructure:"failure,omitempty"`
+	Dir         string    `mapstructure:"dir" yaml:"dir"`
+	PreValidate HookArray `mapstructure:"prevalidate,omitempty" yaml:"prevalidate,omitempty"`
+	Before      HookArray `mapstructure:"before,omitempty" yaml:"before,omitempty"`
+	After       HookArray `mapstructure:"after,omitempty" yaml:"after,omitempty"`
+	Success     HookArray `mapstructure:"success,omitempty" yaml:"success,omitempty"`
+	Failure     HookArray `mapstructure:"failure,omitempty" yaml:"failure,omitempty"`
 }
 
 type LocationCopy = map[string][]string
 
 type Location struct {
-	name         string               `mapstructure:",omitempty"`
-	From         []string             `mapstructure:"from,omitempty"`
-	Type         string               `mapstructure:"type,omitempty"`
-	To           []string             `mapstructure:"to,omitempty"`
-	Hooks        Hooks                `mapstructure:"hooks,omitempty"`
-	Cron         string               `mapstructure:"cron,omitempty"`
-	Options      Options              `mapstructure:"options,omitempty"`
-	ForgetOption LocationForgetOption `mapstructure:"forget,omitempty"`
-	CopyOption   LocationCopy         `mapstructure:"copy,omitempty"`
+	name         string               `mapstructure:",omitempty" yaml:",omitempty"`
+	From         []string             `mapstructure:"from,omitempty" yaml:"from,omitempty"`
+	Type         string               `mapstructure:"type,omitempty" yaml:"type,omitempty"`
+	To           []string             `mapstructure:"to,omitempty" yaml:"to,omitempty"`
+	Hooks        Hooks                `mapstructure:"hooks,omitempty" yaml:"hooks,omitempty"`
+	Cron         string               `mapstructure:"cron,omitempty" yaml:"cron,omitempty"`
+	Options      Options              `mapstructure:"options,omitempty" yaml:"options,omitempty"`
+	ForgetOption LocationForgetOption `mapstructure:"forget,omitempty" yaml:"forget,omitempty"`
+	CopyOption   LocationCopy         `mapstructure:"copy,omitempty" yaml:"copy,omitempty"`
 }
 
 func GetLocation(name string) (Location, bool) {


### PR DESCRIPTION
There's a number of open issues about crashes coming from `forgetoption` and `configoption`:
- https://github.com/cupcakearmy/autorestic/issues/351
- https://github.com/cupcakearmy/autorestic/issues/315
- https://github.com/cupcakearmy/autorestic/issues/194

This happens when `autorestic` generates a secret key for a backend that doesn't already have one. Under the hood `autorestic` will generate the key and then write the config to disk. During this write operation, invalid config options were introduced which leads `autorestic` to crash on following runs. 

This bug happens because of a quirk in `viper` (the config lib used by `autorestic`). When `viper` reads a config to a `struct` it does so using the `mapstructure` tags but when it write the config from a `struct` it doesn't use those. It instead just passes it to https://pkg.go.dev/gopkg.in/yaml.v2 which uses the `yaml` tags.

The fix here is a bit of a hack. I simply duplicated all the `mapstructure` tags into new `yaml` tags with the exact same values. The `mapstructure` tags are used for reading and the `yaml` tags are used for writing. This is obviously ugly but it does fix the issue.

I know that @cupcakearmy had some plans of removing the config writing feature from `autorestic`. While I think that this is a good idea in the long run, I'm hoping that this fix here is a good way to fix the bug without introducing a potentially breaking change for users.

## Example result

Here's an example of the resulting config from this PR:

`example-config.yml`:

```yaml
version: 2
locations:
  test:
    type: local
    from: test
    to: [example]
backends:
  example:
    type: local
    path: foo
```

Generating the `key`:

```yaml
$ go run . check -c example-config.yml 
Using config: 	 /home/dotboris/code/autorestic/example-config.yml
Using lock:	 .autorestic.lock.yml
Saved a backup copy of your file next to the original.
Initializing backend "example"...
Everything is fine.
```

Updated config:

```yaml
backends:
  example:
    type: local
    path: foo
    key: 6qC9thANvNfz3M9VekpjM4QYPNtVYbBkD40hnIjd03x0ekEqwyFevLRApfqYZi1OfWlMvZC4rNntliODPzYw
locations:
  test:
    from:
    - test
    type: local
    to:
    - example
version: 2
```

Notice that `autorestic` has written a `key` for the `example` backend but the config is not polluted with noisy fields. The only issue with this is that the fields are re-ordered. This is not great but I believe that it's tolerable.