### PR TITLE
Cron: Return a non-zero exit code when errors are encountered during backup

### DIFF
--- a/internal/cron.go
+++ b/internal/cron.go
@@ -1,12 +1,22 @@
 package internal
 
+import (
+	"errors"
+	"fmt"
+)
+
 func RunCron() error {
 	c := GetConfig()
+	var errs []error
 	for name, l := range c.Locations {
 		l.name = name
 		if err := l.RunCron(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("Encountered errors during cron process:\n%w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/internal/location.go
+++ b/internal/location.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -446,7 +447,10 @@ func (l Location) RunCron() error {
 	now := time.Now()
 	if now.After(next) {
 		lock.SetCron(l.name, now.Unix())
-		l.Backup(true, "")
+		errs := l.Backup(true, "")
+		if len(errs) > 0 {
+			return fmt.Errorf("Failed to backup location \"%s\":\n%w", l.name, errors.Join(errs...))
+		}
 	} else {
 		if !flags.CRON_LEAN {
 			colors.Body.Printf("Skipping \"%s\", not due yet.\n", l.name)


### PR DESCRIPTION
Fixes: #400

This PR makes it so that `autorestic cron` crashes (returns a non-zero exit code) when there's an error during one of the backups. All errors are collected and printed out at the end of the run.

Note that this new behavior does not stop `autorestic cron` from running all backups. It will attempt to backup all locations that are scheduled and collect errors. It will only crash at the end of this process.