### PR TITLE
Improve error handling in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e -o pipefail
 shopt -s nocaseglob
 
 OUT_FILE=/usr/local/bin/autorestic


### PR DESCRIPTION
Prior to this change, running the example from the docs without root privs produces this misleading/confusing output that claims that the software was installed when it wasn't:

```console
$ wget -qO - https://raw.githubusercontent.com/cupcakearmy/autorestic/master/install.sh | bash
linux
amd64
/usr/local/bin/autorestic.bz2: Permission denied
bzip2: Can't open input file /usr/local/bin/autorestic.bz2: No such file or directory.
chmod: cannot access '/usr/local/bin/autorestic': No such file or directory
bash: line 49: autorestic: command not found
Successfully installed autorestic
```

With this change, the errors stop the script much earlier and produce this output instead:

```
linux
amd64
/usr/local/bin/autorestic.bz2: Permission denied
```