### PR TITLE
Skip timestamp update for failed cron runs

### DIFF
--- a/internal/location.go
+++ b/internal/location.go
@@ -446,11 +446,11 @@ func (l Location) RunCron() error {
 	next := schedule.Next(last)
 	now := time.Now()
 	if now.After(next) {
-		lock.SetCron(l.name, now.Unix())
 		errs := l.Backup(true, "")
 		if len(errs) > 0 {
 			return fmt.Errorf("Failed to backup location \"%s\":\n%w", l.name, errors.Join(errs...))
 		}
+		lock.SetCron(l.name, now.Unix())
 	} else {
 		if !flags.CRON_LEAN {
 			colors.Body.Printf("Skipping \"%s\", not due yet.\n", l.name)


### PR DESCRIPTION
This is a fix for https://github.com/cupcakearmy/autorestic/issues/343 where the cron timestamp gets updated before the run, so any job failure prevents another cron for that period from succeeding.