### PR TITLE
Add Windows Specific Code To Run Commands With Powershell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test
 autorestic
 data
 dist
+*.exe

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/cupcakearmy/autorestic/internal"
@@ -37,10 +38,17 @@ func Execute() {
 }
 
 func init() {
+	restic := "restic"
+	// For Windows we default the executable differently as the current directory
+	// is usually not included in search path by default.
+	if runtime.GOOS == "windows" {
+		restic = "./restic"
+	}
+
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.autorestic.yml or ./.autorestic.yml)")
 	rootCmd.PersistentFlags().BoolVar(&flags.CI, "ci", false, "CI mode disabled interactive mode and colors and enables verbosity")
 	rootCmd.PersistentFlags().BoolVarP(&flags.VERBOSE, "verbose", "v", false, "verbose mode")
-	rootCmd.PersistentFlags().StringVar(&flags.RESTIC_BIN, "restic-bin", "restic", "specify custom restic binary")
+	rootCmd.PersistentFlags().StringVar(&flags.RESTIC_BIN, "restic-bin", restic, "specify custom restic binary")
 	rootCmd.PersistentFlags().StringVar(&flags.DOCKER_IMAGE, "docker-image", "cupcakearmy/autorestic:"+internal.VERSION, "specify a custom docker image")
 	cobra.OnInitialize(initConfig)
 }

--- a/internal/location.go
+++ b/internal/location.go
@@ -139,7 +139,7 @@ func (l Location) ExecuteHooks(commands []string, options ExecuteOptions) error 
 	colors.Secondary.Println("\nRunning hooks")
 	for _, command := range commands {
 		colors.Body.Println("> " + command)
-		_, out, err := ExecuteCommand(options, "-c", command)
+		_, out, err := ExecuteCommand(options, shellArgs, command)
 		if err != nil {
 			colors.Error.Println(out)
 			return err
@@ -179,7 +179,7 @@ func (l Location) Backup(cron bool, specificBackend string) []error {
 	}
 	cwd, _ := GetPathRelativeToConfig(".")
 	options := ExecuteOptions{
-		Command: "bash",
+		Command: shellName,
 		Dir:     cwd,
 		Envs: map[string]string{
 			"AUTORESTIC_LOCATION": l.name,

--- a/internal/shell.go
+++ b/internal/shell.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package internal
+
+import "os/exec"
+
+const shellName string = "bash"
+const shellArg string = "-c"
+
+func execCommand(cmd string, args ...string) *exec.Cmd {
+	return exec.Command(cmd, args...)
+}

--- a/internal/shell.go
+++ b/internal/shell.go
@@ -5,7 +5,7 @@ package internal
 import "os/exec"
 
 const shellName string = "bash"
-const shellArg string = "-c"
+const shellArgs string = "-c"
 
 func execCommand(cmd string, args ...string) *exec.Cmd {
 	return exec.Command(cmd, args...)

--- a/internal/shell_windows.go
+++ b/internal/shell_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package internal
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const shellName string = "PowerShell"
+const shellArgs string = "-Command"
+
+func execCommand(command string, args ...string) *exec.Cmd {
+	cmd := exec.Command(command, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -40,7 +40,7 @@ func (w ColoredWriter) Write(p []byte) (n int, err error) {
 }
 
 func ExecuteCommand(options ExecuteOptions, args ...string) (int, string, error) {
-	cmd := exec.Command(options.Command, args...)
+	cmd := execCommand(options.Command, args...)
 	env := os.Environ()
 	for k, v := range options.Envs {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION
For Windows, run commands with PowerShell -C <command> and the window the command runs in hidden. I've tested this running backups with hooks and it seems to work.

Also default the executable to "./restic" as Windows shells typically don't search the current directory. This default can still be overridden with the --restic-bin flag.

Should have no effect on other platforms.