### PR TITLE
Add code to support downloading and updating restic for Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test
 autorestic
 data
 dist
+*.exe

--- a/internal/bins/decompress.go
+++ b/internal/bins/decompress.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package bins
+
+const formatName string = "bz2"
+
+func installPath() string {
+	return "/usr/local/bin"
+}
+
+func decompress(resp *http.Response) (io.ReadCloser, error) {
+	return bzip2.NewReader(resp.Body)
+}
+
+func exeName(f string) string {
+	return f
+}

--- a/internal/bins/decompress_windows.go
+++ b/internal/bins/decompress_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package bins
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+const formatName string = "zip"
+
+func installPath() string {
+	return fmt.Sprintf("%s%cSystem32", os.Getenv("SYSTEMROOT"), os.PathSeparator)
+}
+
+func decompress(resp *http.Response) (io.ReadCloser, error) {
+	// Have to copy the response as we need to get an io.ReaderAt for the zip API.
+	buff := bytes.NewBuffer([]byte{})
+	size, err := io.Copy(buff, resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	z, err := zip.NewReader(bytes.NewReader(buff.Bytes()), size)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(z.File) != 1 {
+		return nil, fmt.Errorf("Expecting one file in zip download, got:%d", len(z.File))
+	}
+
+	return z.File[0].Open()
+}
+
+func exeName(f string) string {
+	return fmt.Sprintf("%s/%s.exe", installPath, f)
+}


### PR DESCRIPTION
For Windows, add support for downloading the zip version of restic and uncompressing it.  Set the install path to System32 under SystemRoot, though I'm open to suggestions whether this is the best place as there is no real equivalent to /usr/local/bin.