### PR TITLE
feat: Add --dry-run to backup command

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -18,9 +18,11 @@ var backupCmd = &cobra.Command{
 		err := lock.Lock()
 		CheckErr(err)
 		defer lock.Unlock()
+		dry, _ := cmd.Flags().GetBool("dry-run")
 
 		selected, err := internal.GetAllOrSelected(cmd, false)
 		CheckErr(err)
+
 		errors := 0
 		for _, name := range selected {
 			var splitted = strings.Split(name, "@")
@@ -29,7 +31,7 @@ var backupCmd = &cobra.Command{
 				specificBackend = splitted[1]
 			}
 			location, _ := internal.GetLocation(splitted[0])
-			errs := location.Backup(false, specificBackend)
+			errs := location.Backup(false, dry, specificBackend)
 			for _, err := range errs {
 				colors.Error.Printf("%s\n\n", err)
 				errors++
@@ -44,4 +46,5 @@ var backupCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(backupCmd)
 	internal.AddFlagsToCommand(backupCmd, false)
+	backupCmd.Flags().Bool("dry-run", false, "do not write changes, show what would be affected")
 }

--- a/docs/pages/cli/backup.md
+++ b/docs/pages/cli/backup.md
@@ -1,10 +1,13 @@
 # Backup
 
 ```bash
-autorestic backup [-l, --location] [-a, --all]
+autorestic backup [-l, --location] [-a, --all] [--dry-run]
 ```
 
 Performs a backup of all locations if the `-a` flag is passed. To only backup some locations pass one or more `-l` or `--location` flags.
+
+The `--dry-run` flag will do a dry run showing what would have been deleted, but won't touch the actual data.
+
 
 ```bash
 # All

--- a/internal/location.go
+++ b/internal/location.go
@@ -168,7 +168,7 @@ func (l Location) getLocationTags() string {
 	return buildTag("location", l.name)
 }
 
-func (l Location) Backup(cron bool, specificBackend string) []error {
+func (l Location) Backup(cron bool, dry bool, specificBackend string) []error {
 	var errors []error
 	var backends []string
 	colors.PrimaryPrint("  Backing up location \"%s\"  ", l.name)
@@ -227,6 +227,9 @@ func (l Location) Backup(cron bool, specificBackend string) []error {
 		cmd = append(cmd, combineAllOptions("backup", l, backend)...)
 		if cron {
 			cmd = append(cmd, "--tag", buildTag("cron"))
+		}
+		if dry {
+			cmd = append(cmd, "--dry-run")
 		}
 		cmd = append(cmd, "--tag", l.getLocationTags())
 		backupOptions := ExecuteOptions{
@@ -447,7 +450,7 @@ func (l Location) RunCron() error {
 	now := time.Now()
 	if now.After(next) {
 		lock.SetCron(l.name, now.Unix())
-		errs := l.Backup(true, "")
+		errs := l.Backup(true, false, "")
 		if len(errs) > 0 {
 			return fmt.Errorf("Failed to backup location \"%s\":\n%w", l.name, errors.Join(errs...))
 		}


### PR DESCRIPTION
Restic supports --dry-run for backups since 0.13.0 [1] and this adds support for that.

[1] https://github.com/restic/restic/commit/bc97a3d1f9f4bf5a348d95ca77353fa215376879