### PR TITLE
Allow lockfile path to be configured

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cupcakearmy/autorestic/internal"
 	"github.com/cupcakearmy/autorestic/internal/colors"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/spf13/cobra"
 )
 
@@ -15,9 +14,9 @@ var backupCmd = &cobra.Command{
 	Short: "Create backups for given locations",
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.GetConfig()
-		err := lock.Lock()
+		err := internal.Lock()
 		CheckErr(err)
-		defer lock.Unlock()
+		defer internal.Unlock()
 		dry, _ := cmd.Flags().GetBool("dry-run")
 
 		selected, err := internal.GetAllOrSelected(cmd, false)

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/cupcakearmy/autorestic/internal"
 	"github.com/cupcakearmy/autorestic/internal/colors"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/spf13/cobra"
 )
 
@@ -12,9 +11,9 @@ var checkCmd = &cobra.Command{
 	Short: "Check if everything is setup",
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.GetConfig()
-		err := lock.Lock()
+		err := internal.Lock()
 		CheckErr(err)
-		defer lock.Unlock()
+		defer internal.Unlock()
 
 		CheckErr(internal.CheckConfig())
 

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/cupcakearmy/autorestic/internal"
 	"github.com/cupcakearmy/autorestic/internal/flags"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +12,9 @@ var cronCmd = &cobra.Command{
 	Long:  `Intended to be mainly triggered by an automated system like systemd or crontab. For each location checks if a cron backup is due and runs it.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.GetConfig()
-		err := lock.Lock()
+		err := internal.Lock()
 		CheckErr(err)
-		defer lock.Unlock()
+		defer internal.Unlock()
 
 		err = internal.RunCron()
 		CheckErr(err)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cupcakearmy/autorestic/internal"
 	"github.com/cupcakearmy/autorestic/internal/colors"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/spf13/cobra"
 )
 
@@ -14,9 +13,9 @@ var execCmd = &cobra.Command{
 	Short: "Execute arbitrary native restic commands for given backends",
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.GetConfig()
-		err := lock.Lock()
+		err := internal.Lock()
 		CheckErr(err)
-		defer lock.Unlock()
+		defer internal.Unlock()
 
 		selected, err := internal.GetAllOrSelected(cmd, true)
 		CheckErr(err)

--- a/cmd/forget.go
+++ b/cmd/forget.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/cupcakearmy/autorestic/internal"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/spf13/cobra"
 )
 
@@ -11,9 +10,9 @@ var forgetCmd = &cobra.Command{
 	Short: "Forget and optionally prune snapshots according the specified policies",
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.GetConfig()
-		err := lock.Lock()
+		err := internal.Lock()
 		CheckErr(err)
-		defer lock.Unlock()
+		defer internal.Unlock()
 
 		selected, err := internal.GetAllOrSelected(cmd, false)
 		CheckErr(err)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/cupcakearmy/autorestic/internal"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/spf13/cobra"
 )
 
@@ -14,9 +13,9 @@ var restoreCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.GetConfig()
-		err := lock.Lock()
+		err := internal.Lock()
 		CheckErr(err)
-		defer lock.Unlock()
+		defer internal.Unlock()
 
 		location, _ := cmd.Flags().GetString("location")
 		l, ok := internal.GetLocation(location)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cupcakearmy/autorestic/internal"
 	"github.com/cupcakearmy/autorestic/internal/colors"
 	"github.com/cupcakearmy/autorestic/internal/flags"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -18,7 +17,7 @@ import (
 func CheckErr(err error) {
 	if err != nil {
 		colors.Error.Fprintln(os.Stderr, "Error:", err)
-		lock.Unlock()
+		internal.Unlock()
 		os.Exit(1)
 	}
 }
@@ -42,6 +41,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&flags.VERBOSE, "verbose", "v", false, "verbose mode")
 	rootCmd.PersistentFlags().StringVar(&flags.RESTIC_BIN, "restic-bin", "restic", "specify custom restic binary")
 	rootCmd.PersistentFlags().StringVar(&flags.DOCKER_IMAGE, "docker-image", "cupcakearmy/autorestic:"+internal.VERSION, "specify a custom docker image")
+	rootCmd.PersistentFlags().StringVar(&flags.LOCKFILE, "lockfile", "", "specify a custom path for the lockfile (defaults to .autorestic.lock.yml next to the loaded autorestic config file)")
 	cobra.OnInitialize(initConfig)
 }
 

--- a/cmd/unlock.go
+++ b/cmd/unlock.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cupcakearmy/autorestic/internal"
 	"github.com/cupcakearmy/autorestic/internal/colors"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/spf13/cobra"
 )
 
@@ -33,7 +32,7 @@ To check you can run "ps aux | grep autorestic".`,
 			}
 		}
 
-		err := lock.Unlock()
+		err := internal.Unlock()
 		if err != nil {
 			colors.Error.Println("Could not unlock:", err)
 			return

--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -3,6 +3,7 @@
   "quick": "Quick Start",
   "installation": "Installation",
   "config": "Configuration",
+  "lockfile": "Lockfile",
   "location": "Locations",
   "backend": "Backend",
   "cli": "CLI",

--- a/docs/pages/cli/general.md
+++ b/docs/pages/cli/general.md
@@ -34,3 +34,11 @@ With `--restic-bin` you can specify to run a specific restic binary. This can be
 ```bash
 autorestic --restic-bin /some/path/to/my/custom/restic/binary
 ```
+
+## `--lockfile`
+
+Specify the path for the [lockfile](../lockfile.md) used by `autorestic`. If omitted, this will default to `.autorestic.lock.yml` next to the loaded config file.
+
+```bash
+autorestic --lockfile /path/to/my/.autorestic.lock.yml
+```

--- a/docs/pages/lockfile.md
+++ b/docs/pages/lockfile.md
@@ -1,0 +1,14 @@
+# Lockfile
+
+Under the hood, `autorestic` uses a lockfile to ensure that only one instance is running and to keep track of when [cronjobs](./location/cron.md) were last run.
+
+By default, the lockfile is stored next to your [configuration file](./config.md) as `.autorestic.lock.yml`. In other words, if your config file is located at `/some/path/.autorestic.yml`, then the lockfile will be located at `/some/path/.autorestic.lock.yml`.
+
+## Customization
+
+The path to the lockfile can be customized if need be. This can be done is a few ways:
+
+1. Using the `--lockfile ...` command line flag
+1. Setting `lockfile: ...` in the configuration file
+
+Note that `autorestic` will check for a customized lockfile path in the order listed above. This means that if you specify a lockfile path in multiple places, the method that's higher in the list will win.

--- a/internal/config.go
+++ b/internal/config.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cupcakearmy/autorestic/internal/colors"
 	"github.com/cupcakearmy/autorestic/internal/flags"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/joho/godotenv"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -24,6 +23,7 @@ type Options map[string]OptionMap
 
 type Config struct {
 	Version   string              `mapstructure:"version" yaml:"version"`
+	Lockfile  string              `mapstructure:"lockfile,omitempty" yaml:"lockfile,omitempty"`
 	Extras    interface{}         `mapstructure:"extras" yaml:"extras"`
 	Locations map[string]Location `mapstructure:"locations" yaml:"locations"`
 	Backends  map[string]Backend  `mapstructure:"backends" yaml:"backends"`
@@ -40,7 +40,7 @@ func exitConfig(err error, msg string) {
 	if msg != "" {
 		colors.Error.Println(msg)
 	}
-	lock.Unlock()
+	Unlock()
 	os.Exit(1)
 }
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,9 +1,10 @@
 package flags
 
 var (
-	CI         bool = false
-	VERBOSE    bool = false
-	CRON_LEAN  bool = false
-	RESTIC_BIN string
+	CI           bool = false
+	VERBOSE      bool = false
+	CRON_LEAN    bool = false
+	RESTIC_BIN   string
 	DOCKER_IMAGE string
+	LOCKFILE     string
 )

--- a/internal/location.go
+++ b/internal/location.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cupcakearmy/autorestic/internal/colors"
 	"github.com/cupcakearmy/autorestic/internal/flags"
-	"github.com/cupcakearmy/autorestic/internal/lock"
 	"github.com/cupcakearmy/autorestic/internal/metadata"
 	"github.com/robfig/cron"
 )
@@ -445,11 +444,11 @@ func (l Location) RunCron() error {
 	if err != nil {
 		return err
 	}
-	last := time.Unix(lock.GetCron(l.name), 0)
+	last := time.Unix(GetCron(l.name), 0)
 	next := schedule.Next(last)
 	now := time.Now()
 	if now.After(next) {
-		lock.SetCron(l.name, now.Unix())
+		SetCron(l.name, now.Unix())
 		errs := l.Backup(true, false, "")
 		if len(errs) > 0 {
 			return fmt.Errorf("Failed to backup location \"%s\":\n%w", l.name, errors.Join(errs...))

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"syscall"
 
 	"github.com/cupcakearmy/autorestic/cmd"
-	"github.com/cupcakearmy/autorestic/internal/lock"
+	"github.com/cupcakearmy/autorestic/internal"
 )
 
 func handleCtrlC() {
@@ -31,7 +31,7 @@ func handleCtrlC() {
 	go func() {
 		sig := <-c
 		fmt.Println("Signal:", sig)
-		lock.Unlock()
+		internal.Unlock()
 		os.Exit(0)
 	}()
 }


### PR DESCRIPTION
Bringing back https://github.com/cupcakearmy/autorestic/pull/384 as it is something I (and I am sure others) would find useful.

I just cherry picked the exact commits from that PR so the code changes are exactly the same, just squashed and rebased.

Description from the previous PR:
> The goal of this feature is to allow users to control the path of the lockfile. This is useful in situations where you don't want the lockfile to default next to the config file.
>
> For my use case, I want to generate the config file with Nix which will store it in a read-only path. In such a situation autorestic won't be able to create the lockfile.
>
> This PR adds a few ways to let users control their lockfile path:
> - Using the new --lockfile flag
> - Using the new lockfile: ... config option
>
> Note that this PR includes a refactor that merges the lock package back into the internal package. This is done to avoid a circular dependency where the lock package needs to read the config from the internal package but the internal package also needs to use the lock package.